### PR TITLE
Update license in package.json, add homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
     "Two-Factor Authentication"
   ],
   "author": "Duo Security",
-  "licenses": [
-    {
-      "type": "Duo License",
-      "url": "https://github.com/duosecurity/duo_web_client/blob/master/LICENSE"
-    }
-  ]
+  "license": "SEE LICENSE IN LICENSE",
+  "homepage": "https://duo.com"
 }


### PR DESCRIPTION
According to NPM, the `license` field should always be a string. Additionally:

> If you are using a license that hasn't been assigned an SPDX identifier, or if you are using a custom license, use a string value like this one:
> 
> `{ "license" : "SEE LICENSE IN <filename>" }`

https://docs.npmjs.com/files/package.json#license

I also added a `homepage` field.